### PR TITLE
Add anaconda-virtualenv-profile.sh to ensure shell has the same environment as the notebook

### DIFF
--- a/.s2i/bin/assemble
+++ b/.s2i/bin/assemble
@@ -59,15 +59,29 @@ mv ${APP_ROOT}/src/*.sh /opt/app-root/bin
 
 # Install oc command line client for OpenShift cluster.
 
-curl -s -o ${APP_ROOT}/oc.tar.gz https://mirror.openshift.com/pub/openshift-v3/clients/3.11.153/linux/oc.tar.gz && \
+curl -L -o ${APP_ROOT}/oc.tar.gz https://mirror.openshift.com/pub/openshift-v3/clients/3.11.153/linux/oc.tar.gz
+
+# Check if oc.tar.gz is not empty
+if [ -s ${APP_ROOT}/oc.tar.gz ]; then
     tar -C /opt/app-root/bin -zxf ${APP_ROOT}/oc.tar.gz oc && \
     mv /opt/app-root/bin/oc /opt/app-root/bin/oc-3.11 && \
     rm ${APP_ROOT}/oc.tar.gz
+else
+    echo "ERROR: Couldn't download OCP 3.11 client binary."
+    exit 1
+fi
 
-curl -s -o ${APP_ROOT}/oc.tar.gz https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest/linux/oc.tar.gz&& \
+curl -L -o ${APP_ROOT}/oc.tar.gz https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest/linux/oc.tar.gz
+
+# Check if oc.tar.gz is not empty
+if [ -s ${APP_ROOT}/oc.tar.gz ]; then
     tar -C /opt/app-root/bin -zxf ${APP_ROOT}/oc.tar.gz oc && \
     mv /opt/app-root/bin/oc /opt/app-root/bin/oc-4 && \
     rm ${APP_ROOT}/oc.tar.gz
+else
+    echo "ERROR: Couldn't download OCP 4 client binary."
+    exit 1
+fi
 
 ln -s /opt/app-root/bin/oc-wrapper.sh /opt/app-root/bin/oc
 


### PR DESCRIPTION
For some reason, environment variables differ between shell and jupyter
notebook. This addresses the Anaconda side of the problem by ensuring we
source ${APP_ROOT}'s virtualenv in /etc/profile.d

- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [X] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [ ] JIRA link(s): @guimou can we make a jira for this
- [ ] The Jira story is acked
- [ ] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)
